### PR TITLE
Extrude skeleton a bit further to fully cutout bottom

### DIFF
--- a/lib/gridfinityUtils/baseplateGenerator.py
+++ b/lib/gridfinityUtils/baseplateGenerator.py
@@ -68,7 +68,7 @@ def createGridfinityBaseplate(input: BaseplateGeneratorInput, targetComponent: a
         centerCutoutExtrudeFeature = extrudeUtils.simpleDistanceExtrude(
             centerCutoutSketch.profiles.item(0),
             adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
-            input.bottomExtensionHeight,
+            input.bottomExtensionHeight+1,
             adsk.fusion.ExtentDirections.PositiveExtentDirection,
             [],
             targetComponent,


### PR DESCRIPTION
Extrude skeleton a bit more to fully cutout bottom of baseplate, currently skeletonized baseplates have a full bottom, this more closely aligns with typical skeletonized baseplates.