### PR TITLE
3-tier supportless magnet + screw holes

### DIFF
--- a/lib/gridfinityUtils/baseGenerator.py
+++ b/lib/gridfinityUtils/baseGenerator.py
@@ -224,10 +224,7 @@ def createGridfinityBase(
                 
                 if hadScrewHoleCircle:
                     innerGrooveProfiles.append(profile)
-
-            app.log("Inner Groove Profiles: " + str(len(innerGrooveProfiles)))
-            app.log("Outer Groove Profiles: " + str(len(outerGrooveProfiles)))
-
+                    
             printHelperOuterGrooveCutInput = extrudeFeatures.createInput(
                 commonUtils.objectCollectionFromList(outerGrooveProfiles),
                 adsk.fusion.FeatureOperations.CutFeatureOperation,


### PR DESCRIPTION
Decided to learn how to use the F360 Python API and contribute, since I find your plugin useful.

This should add an extra extrusion to cut out another layer from the supportless magnet + screw holes, which will allow many slicers to print this a bit more neatly.

I'm not exactly a python programmer at my day-job, so please feel free to suggest edits, if my code isn't idiomatic, or if I've done something dumb.

Here's a screenshot of how it looks, when generating a bin:
![image](https://user-images.githubusercontent.com/865682/227811760-5ce1c4b4-e792-4dfe-a411-6ee870221dbd.png)

Example of how the old version prints, on my printer:
![image](https://user-images.githubusercontent.com/865682/227811790-7aa16ce0-a3c0-45ce-aa56-d1fbb887293f.png)

Example of how the new version prints, on my printer:
![image](https://user-images.githubusercontent.com/865682/227811801-f0d5c7a9-73f0-4fe6-adce-ac5a9836f639.png)
