### PR TITLE
- Added Scoop max radius input

### DIFF
--- a/commands/commandCreateBin/inputState.py
+++ b/commands/commandCreateBin/inputState.py
@@ -28,6 +28,7 @@ class InputState:
     compartmentsGridLength: int
     compartmentsGridType: str
     hasScoop: bool
+    scoopMaxRadius: float
     hasTab: bool
     tabLength: float
     tabWidth: float

--- a/lib/gridfinityUtils/binBodyCutoutGenerator.py
+++ b/lib/gridfinityUtils/binBodyCutoutGenerator.py
@@ -56,10 +56,10 @@ def createGridfinityBinBodyCutout(
     if input.hasScoop:
         [innerCutoutScoopFace, innerCutoputScoopOppositeFace] = getInnerCutoutScoopFace(innerCutoutBody)
         scoopEdge = faceUtils.getBottomHorizontalEdge(innerCutoutScoopFace.edges)
-        scoopRadius = min(const.BIN_SCOOP_MAX_RADIUS, input.height)
+        scoopMaxRadius = min(input.scoopMaxRadius, input.height) if min(input.scoopMaxRadius, input.height) >= input.filletRadius else input.filletRadius
         filletUtils.createFillet(
             [scoopEdge],
-            scoopRadius,
+            scoopMaxRadius,
             False,
             targetComponent
         )

--- a/lib/gridfinityUtils/binBodyCutoutGeneratorInput.py
+++ b/lib/gridfinityUtils/binBodyCutoutGeneratorInput.py
@@ -5,6 +5,7 @@ from . import const
 class BinBodyCutoutGeneratorInput():
     def __init__(self):
         self.hasScoop = False
+        self.scoopMaxRadius = const.BIN_SCOOP_MAX_RADIUS
         self.tabOverhangAngle = const.BIN_TAB_OVERHANG_ANGLE
         self.tabPosition = 0
         self.tabLength = 1
@@ -50,6 +51,14 @@ class BinBodyCutoutGeneratorInput():
     @hasScoop.setter
     def hasScoop(self, value: bool):
         self._hasScoop = value
+
+    @property
+    def scoopMaxRadius(self) -> float:
+        return self._scoopMaxRadius
+
+    @scoopMaxRadius.setter
+    def scoopMaxRadius(self, value: float):
+        self._scoopMaxRadius = value
 
     @property
     def filletRadius(self) -> float:

--- a/lib/gridfinityUtils/binBodyGenerator.py
+++ b/lib/gridfinityUtils/binBodyGenerator.py
@@ -135,6 +135,7 @@ def createGridfinityBinBody(
                 compartmentLengthUnit * compartment.length + (compartment.length - 1) * input.wallThickness,
                 min(binBodyTotalHeight - const.BIN_COMPARTMENT_BOTTOM_THICKNESS, compartment.depth),
                 input.hasScoop,
+                input.scoopMaxRadius,
                 input.hasTab,
                 max(0, min(input.tabLength, input.binWidth)) * input.baseWidth,
                 input.tabWidth,
@@ -168,6 +169,7 @@ def createCompartment(
         length: float,
         depth: float,
         hasScoop: bool,
+        scoopMaxRadius: float,
         hasTab: bool,
         tabLength: float,
         tabWidth: float,
@@ -185,6 +187,7 @@ def createCompartment(
     innerCutoutInput.length = length
     innerCutoutInput.height = depth
     innerCutoutInput.hasScoop = hasScoop
+    innerCutoutInput.scoopMaxRadius = scoopMaxRadius
     innerCutoutInput.hasTab = hasTab
     innerCutoutInput.tabLength = tabLength
     innerCutoutInput.tabWidth = tabWidth

--- a/lib/gridfinityUtils/binBodyGeneratorInput.py
+++ b/lib/gridfinityUtils/binBodyGeneratorInput.py
@@ -58,6 +58,7 @@ class BinBodyGeneratorInput():
         self.hasLip = False
         self.hasLipNotches = False
         self.hasScoop = False
+        self.scoopMaxRadius = const.BIN_SCOOP_MAX_RADIUS
         self.tabOverhangAngle = const.BIN_TAB_OVERHANG_ANGLE
         self.tabPosition = 0
         self.tabLength = 1
@@ -161,6 +162,14 @@ class BinBodyGeneratorInput():
     @hasScoop.setter
     def hasScoop(self, value: bool):
         self._hasScoop = value
+
+    @property
+    def scoopMaxRadius(self) -> float:
+        return self._scoopMaxRadius
+
+    @scoopMaxRadius.setter
+    def scoopMaxRadius(self, value: float):
+        self._scoopMaxRadius = value
 
     @property
     def hasTab(self) -> bool:


### PR DESCRIPTION
Don't know if anyone needs this, was making some small compartments and had to modify the fillet manually for each one so I added the option to set a max scoop radius instead of the default 25mm.

This `scoopMaxRadius` implementation sets it so it doesn't go any lower than inner wall `filletRadius`.

PS: From my testing, it seems to be working just fine but I've never written python before. I just copied what `tabWidth` input does.