### PR TITLE
Add info section to generators

### DIFF
--- a/commands/commandCreateBaseplate/entry.py
+++ b/commands/commandCreateBaseplate/entry.py
@@ -69,7 +69,7 @@ SHOW_PREVIEW_INPUT = 'show_preview'
 
 INFO_TEXT = ("<b>Help:</b> Info for inputs can be found "
              "<a href=\"https://github.com/Le0Michine/FusionGridfinityGenerator/wiki/Bin-generator-options\">"
-             "Here on our GitHub</a>.'")
+             "Here on our GitHub</a>.")
 
 INPUTS_VALID = True
 
@@ -127,12 +127,6 @@ def stop():
         command_definition.deleteMe()
 
 
-def render_info(inputs: adsk.core.CommandInputs):
-    infoGroup: adsk.core.GroupCommandInput = inputs.itemById(INFO_GROUP_ID)
-    infoGroup.CommandInputs.addTextBoxCommandInput(INFO_TEXT)
-
-
-
 # Function that is called when a user clicks the corresponding button in the UI.
 # This defines the contents of the command dialog and connects to the command related events.
 def command_created(args: adsk.core.CommandCreatedEventArgs):
@@ -144,7 +138,8 @@ def command_created(args: adsk.core.CommandCreatedEventArgs):
     # https://help.autodesk.com/view/fusion360/ENU/?contextId=CommandInputs
     inputs = args.command.commandInputs
 
-    render_info(inputs)
+    infoGroup = inputs.addGroupCommandInput(INFO_GROUP_ID, 'Info')
+    infoGroup.children.addTextBoxCommandInput("info_text", "Info", INFO_TEXT, 3, True)
 
     # Create a value input field and set the default using 1 unit of the default length unit.
     defaultLengthUnits = app.activeProduct.unitsManager.defaultLengthUnits

--- a/commands/commandCreateBaseplate/entry.py
+++ b/commands/commandCreateBaseplate/entry.py
@@ -68,13 +68,13 @@ BASEPLATE_CONNECTION_HOLE_DIAMETER_INPUT = 'connection_hole_diameter'
 SHOW_PREVIEW_INPUT = 'show_preview'
 
 INFO_TEXT = ("<b>Help:</b> Info for inputs can be found "
-             "<a href=\"https://github.com/Le0Michine/FusionGridfinityGenerator/wiki/Bin-generator-options\">"
+             "<a href=\"https://github.com/Le0Michine/FusionGridfinityGenerator/wiki/Baseplate-generator-options\">"
              "Here on our GitHub</a>.")
 
 INPUTS_VALID = True
 
 def getErrorMessage():
-    stackTrace = traceback.format_exc();
+    stackTrace = traceback.format_exc()
     return f"An unknonwn error occurred, please validate your inputs and try again:\n{stackTrace}"
 
 def showErrorInMessageBox():

--- a/commands/commandCreateBaseplate/entry.py
+++ b/commands/commandCreateBaseplate/entry.py
@@ -46,6 +46,7 @@ BIN_XY_TOLERANCE_INPUT_ID = 'bin_xy_tolerance'
 BASEPLATE_WIDTH_INPUT = 'plate_width'
 BASEPLATE_LENGTH_INPUT = 'plate_length'
 BASEPLATE_TYPE_DROPDOWN = 'plate_type_dropdown'
+INFO_GROUP_ID = 'info_group'
 
 BASEPLATE_TYPE_LIGHT = 'Light'
 BASEPLATE_TYPE_FULL = 'Full'
@@ -65,6 +66,10 @@ BASEPLATE_HAS_CONNECTION_HOLE_INPUT = 'has_connection_hole'
 BASEPLATE_CONNECTION_HOLE_DIAMETER_INPUT = 'connection_hole_diameter'
 
 SHOW_PREVIEW_INPUT = 'show_preview'
+
+INFO_TEXT = ("<b>Help:</b> Info for inputs can be found "
+             "<a href=\"https://github.com/Le0Michine/FusionGridfinityGenerator/wiki/Bin-generator-options\">"
+             "Here on our GitHub</a>.'")
 
 INPUTS_VALID = True
 
@@ -122,6 +127,12 @@ def stop():
         command_definition.deleteMe()
 
 
+def render_info(inputs: adsk.core.CommandInputs):
+    infoGroup: adsk.core.GroupCommandInput = inputs.itemById(INFO_GROUP_ID)
+    infoGroup.CommandInputs.addTextBoxCommandInput(INFO_TEXT)
+
+
+
 # Function that is called when a user clicks the corresponding button in the UI.
 # This defines the contents of the command dialog and connects to the command related events.
 def command_created(args: adsk.core.CommandCreatedEventArgs):
@@ -132,6 +143,8 @@ def command_created(args: adsk.core.CommandCreatedEventArgs):
 
     # https://help.autodesk.com/view/fusion360/ENU/?contextId=CommandInputs
     inputs = args.command.commandInputs
+
+    render_info(inputs)
 
     # Create a value input field and set the default using 1 unit of the default length unit.
     defaultLengthUnits = app.activeProduct.unitsManager.defaultLengthUnits

--- a/commands/commandCreateBin/entry.py
+++ b/commands/commandCreateBin/entry.py
@@ -115,7 +115,7 @@ SHOW_PREVIEW_MANUAL_INPUT = 'show_preview_manual'
 
 INFO_TEXT = ("<b>Help:</b> Info for inputs can be found "
              "<a href=\"https://github.com/Le0Michine/FusionGridfinityGenerator/wiki/Bin-generator-options\">"
-             "Here on our GitHub</a>.'")
+             "Here on our GitHub</a>.")
 
 def defaultUiState():
     return InputState(
@@ -317,10 +317,6 @@ def render_compartments_table(inputs: adsk.core.CommandInputs, initiallyVisible:
         append_compartment_table_row(inputs, row.x, row.y, row.width, row.length, row.depth)
 
 
-def render_info(inputs: adsk.core.CommandInputs):
-    infoGroup: adsk.core.GroupCommandInput = inputs.itemById(INFO_GROUP_ID)
-    infoGroup.CommandInputs.addTextBoxCommandInput(INFO_TEXT)
-
 
 def append_compartment_table_row(inputs: adsk.core.CommandInputs, x: int, y: int, w: int, l: int, defaultDepth: float):
     binCompartmentsTable: adsk.core.TableCommandInput = inputs.itemById(BIN_COMPARTMENTS_TABLE_ID)
@@ -419,7 +415,8 @@ def command_created(args: adsk.core.CommandCreatedEventArgs):
     # https://help.autodesk.com/view/fusion360/ENU/?contextId=CommandInputs
     inputs = args.command.commandInputs
 
-    render_info(inputs)
+    infoGroup = inputs.addGroupCommandInput(INFO_GROUP_ID, 'Info')
+    infoGroup.children.addTextBoxCommandInput("info_text", "Info", INFO_TEXT, 3, True)
 
     # Create a value input field and set the default using 1 unit of the default length unit.
     defaultLengthUnits = app.activeProduct.unitsManager.defaultLengthUnits

--- a/commands/commandCreateBin/entry.py
+++ b/commands/commandCreateBin/entry.py
@@ -61,6 +61,7 @@ BIN_TAB_FEATURES_GROUP_ID = 'bin_tab_features_group'
 BIN_BASE_FEATURES_GROUP_ID = 'bin_base_features_group'
 USER_CHANGES_GROUP_ID = 'user_changes_group'
 PREVIEW_GROUP_ID = 'preview_group'
+INFO_GROUP_ID = 'info_group'
 
 BIN_BASE_WIDTH_UNIT_INPUT_ID = 'base_width_unit'
 BIN_BASE_LENGTH_UNIT_INPUT_ID = 'base_length_unit'
@@ -111,6 +112,10 @@ PRESERVE_CHAGES_RADIO_GROUP_RESET = 'Reset inputs after creation'
 RESET_CHAGES_INPUT = 'reset_changes'
 SHOW_PREVIEW_INPUT = 'show_preview'
 SHOW_PREVIEW_MANUAL_INPUT = 'show_preview_manual'
+
+INFO_TEXT = ("<b>Help:</b> Info for inputs can be found "
+             "<a href=\"https://github.com/Le0Michine/FusionGridfinityGenerator/wiki/Bin-generator-options\">"
+             "Here on our GitHub</a>.'")
 
 def defaultUiState():
     return InputState(
@@ -311,6 +316,12 @@ def render_compartments_table(inputs: adsk.core.CommandInputs, initiallyVisible:
     for row in uiState.customCompartments:
         append_compartment_table_row(inputs, row.x, row.y, row.width, row.length, row.depth)
 
+
+def render_info(inputs: adsk.core.CommandInputs):
+    infoGroup: adsk.core.GroupCommandInput = inputs.itemById(INFO_GROUP_ID)
+    infoGroup.CommandInputs.addTextBoxCommandInput(INFO_TEXT)
+
+
 def append_compartment_table_row(inputs: adsk.core.CommandInputs, x: int, y: int, w: int, l: int, defaultDepth: float):
     binCompartmentsTable: adsk.core.TableCommandInput = inputs.itemById(BIN_COMPARTMENTS_TABLE_ID)
     newRow = binCompartmentsTable.rowCount
@@ -407,6 +418,8 @@ def command_created(args: adsk.core.CommandCreatedEventArgs):
 
     # https://help.autodesk.com/view/fusion360/ENU/?contextId=CommandInputs
     inputs = args.command.commandInputs
+
+    render_info(inputs)
 
     # Create a value input field and set the default using 1 unit of the default length unit.
     defaultLengthUnits = app.activeProduct.unitsManager.defaultLengthUnits

--- a/commands/commandCreateBin/entry.py
+++ b/commands/commandCreateBin/entry.py
@@ -153,7 +153,7 @@ staticInputCache = StaticInputCache()
 # json.dumps(asdict(uiState))
 
 def getErrorMessage():
-    stackTrace = traceback.format_exc();
+    stackTrace = traceback.format_exc()
     return f"An unknonwn error occurred, please validate your inputs and try again:\n{stackTrace}"
 
 def showErrorInMessageBox():

--- a/commands/commandCreateBin/entry.py
+++ b/commands/commandCreateBin/entry.py
@@ -316,8 +316,6 @@ def render_compartments_table(inputs: adsk.core.CommandInputs, initiallyVisible:
     for row in uiState.customCompartments:
         append_compartment_table_row(inputs, row.x, row.y, row.width, row.length, row.depth)
 
-
-
 def append_compartment_table_row(inputs: adsk.core.CommandInputs, x: int, y: int, w: int, l: int, defaultDepth: float):
     binCompartmentsTable: adsk.core.TableCommandInput = inputs.itemById(BIN_COMPARTMENTS_TABLE_ID)
     newRow = binCompartmentsTable.rowCount


### PR DESCRIPTION
I was quite confused at first and didn't realize this project had a GitHub because I got it straight from the Fusion360 app store. I just added a little info bubble to the generators, so people can learn what the options do.

![image](https://github.com/Le0Michine/FusionGridfinityGenerator/assets/36117326/257b281b-ff8a-4ddc-9481-9af4260f388b)

The link leads to the wiki page for the generator [the baseplate generator uses this](https://github.com/Le0Michine/FusionGridfinityGenerator/wiki/Baseplate-generator-options)