### PR TITLE
Allow zero bin lip top recess height

### DIFF
--- a/lib/gridfinityUtils/binBodyLipGenerator.py
+++ b/lib/gridfinityUtils/binBodyLipGenerator.py
@@ -49,13 +49,14 @@ def createGridfinityBinBodyLip(
     )
 
     lipCutoutBodies: list[adsk.fusion.BRepBody] = []
-    lipCutoutPlaneInput: adsk.fusion.ConstructionPlaneInput = targetComponent.constructionPlanes.createInput()
-    lipCutoutPlaneInput.setByOffset(
-        lipBodyExtrude.endFaces.item(0),
-        adsk.core.ValueInput.createByReal(0)
-    )
-    lipCutoutConstructionPlane = targetComponent.constructionPlanes.add(lipCutoutPlaneInput)
-    lipCutoutConstructionPlane.name = "lip cutout construction plane"
+    if (const.BIN_LIP_TOP_RECESS_HEIGHT > 0):
+        lipCutoutPlaneInput: adsk.fusion.ConstructionPlaneInput = targetComponent.constructionPlanes.createInput()
+        lipCutoutPlaneInput.setByOffset(
+            lipBodyExtrude.endFaces.item(0),
+            adsk.core.ValueInput.createByReal(0)
+        )
+        lipCutoutConstructionPlane = targetComponent.constructionPlanes.add(lipCutoutPlaneInput)
+        lipCutoutConstructionPlane.name = "lip cutout construction plane"
 
     if input.hasLipNotches:
         lipCutoutInput = BaseGeneratorInput()
@@ -112,15 +113,15 @@ def createGridfinityBinBodyLip(
         lipCutout.name = "lip cutout"
         lipCutoutBodies.append(lipCutout)
 
-    topChamferSketch: adsk.fusion.Sketch = targetComponent.sketches.add(lipCutoutConstructionPlane)
-    topChamferSketch.name = "Lip top chamfer"
-    sketchUtils.createRectangle(
-        actualLipBodyWidth,
-        actualLipBodyLength,
-        topChamferSketch.modelToSketchSpace(adsk.core.Point3D.create(0, 0, topChamferSketch.origin.z)),
-        topChamferSketch,
-    )
     if (const.BIN_LIP_TOP_RECESS_HEIGHT > 0):
+        topChamferSketch: adsk.fusion.Sketch = targetComponent.sketches.add(lipCutoutConstructionPlane)
+        topChamferSketch.name = "Lip top chamfer"
+        sketchUtils.createRectangle(
+            actualLipBodyWidth,
+            actualLipBodyLength,
+            topChamferSketch.modelToSketchSpace(adsk.core.Point3D.create(0, 0, topChamferSketch.origin.z)),
+            topChamferSketch,
+        )
         topChamferNegativeVolume = extrudeUtils.simpleDistanceExtrude(
             topChamferSketch.profiles.item(0),
             adsk.fusion.FeatureOperations.NewBodyFeatureOperation,

--- a/lib/gridfinityUtils/binBodyLipGenerator.py
+++ b/lib/gridfinityUtils/binBodyLipGenerator.py
@@ -120,16 +120,17 @@ def createGridfinityBinBodyLip(
         topChamferSketch.modelToSketchSpace(adsk.core.Point3D.create(0, 0, topChamferSketch.origin.z)),
         topChamferSketch,
     )
-    topChamferNegativeVolume = extrudeUtils.simpleDistanceExtrude(
-        topChamferSketch.profiles.item(0),
-        adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
-        const.BIN_LIP_TOP_RECESS_HEIGHT,
-        adsk.fusion.ExtentDirections.NegativeExtentDirection,
-        [],
-        targetComponent,
-    )
-    topChamferNegativeVolume.name = "Lip top chamfer cut"
-    bodiesToSubtract.append(topChamferNegativeVolume.bodies.item(0))
+    if (const.BIN_LIP_TOP_RECESS_HEIGHT > 0):
+        topChamferNegativeVolume = extrudeUtils.simpleDistanceExtrude(
+            topChamferSketch.profiles.item(0),
+            adsk.fusion.FeatureOperations.NewBodyFeatureOperation,
+            const.BIN_LIP_TOP_RECESS_HEIGHT,
+            adsk.fusion.ExtentDirections.NegativeExtentDirection,
+            [],
+            targetComponent,
+        )
+        topChamferNegativeVolume.name = "Lip top chamfer cut"
+        bodiesToSubtract.append(topChamferNegativeVolume.bodies.item(0))
     bodiesToSubtract = bodiesToSubtract + lipCutoutBodies
 
     combineUtils.cutBody(


### PR DESCRIPTION
I noticed that the top lid of my bins was cut off a bit.
After some code inspection I noticed this was intentional and set by the bin lip top recess height.
I tried setting the `BIN_LIP_TOP_RECESS_HEIGHT` to zero, but that resulted in an error.
This is a fix for those who want to stick to the Gridfinity Design Reference (https://gridfinity.xyz/specification/)