### PR TITLE
Change default Bin height

### DIFF
--- a/commands/commandCreateBin/entry.py
+++ b/commands/commandCreateBin/entry.py
@@ -160,7 +160,7 @@ def initDefaultUiState():
     commandUIState.initValue(BIN_XY_CLEARANCE_INPUT_ID, const.BIN_XY_CLEARANCE, adsk.core.ValueCommandInput.classType())
     commandUIState.initValue(BIN_WIDTH_INPUT_ID, 2, adsk.core.IntegerSpinnerCommandInput.classType())
     commandUIState.initValue(BIN_LENGTH_INPUT_ID, 3, adsk.core.IntegerSpinnerCommandInput.classType())
-    commandUIState.initValue(BIN_HEIGHT_INPUT_ID, 5, adsk.core.ValueCommandInput.classType())
+    commandUIState.initValue(BIN_HEIGHT_INPUT_ID, 6, adsk.core.ValueCommandInput.classType())
 
     commandUIState.initValue(BIN_GENERATE_BODY_INPUT_ID, True, adsk.core.BoolValueCommandInput.classType())
     commandUIState.initValue(BIN_TYPE_DROPDOWN_ID, BIN_TYPE_HOLLOW, adsk.core.DropDownCommandInput.classType())


### PR DESCRIPTION
After fixing https://github.com/Le0Michine/FusionGridfinityGenerator/issues/24 the default bin height is now not the same as the original gridfinity bins, or the ones created by other generators. I suggest changing the size to 6 as the default.
