### PR TITLE
[RFC] Add tabs to magnet cutouts

### DIFF
--- a/commands/commandCreateBin/entry.py
+++ b/commands/commandCreateBin/entry.py
@@ -85,6 +85,7 @@ BIN_GENERATE_BASE_INPUT_ID = 'bin_generate_base'
 BIN_GENERATE_BODY_INPUT_ID = 'bin_generate_body'
 BIN_SCREW_HOLES_INPUT_ID = 'bin_screw_holes'
 BIN_MAGNET_CUTOUTS_INPUT_ID = 'bin_magnet_cutouts'
+BIN_MAGNET_CUTOUTS_TABS_INPUT_ID = 'bin_magnet_cutouts_tabs'
 BIN_SCREW_DIAMETER_INPUT = 'screw_diameter'
 BIN_MAGNET_DIAMETER_INPUT = 'magnet_diameter'
 BIN_MAGNET_HEIGHT_INPUT = 'magnet_height'
@@ -186,6 +187,7 @@ def initDefaultUiState():
     commandUIState.initValue(BIN_SCREW_DIAMETER_INPUT, const.DIMENSION_SCREW_HOLE_DIAMETER, adsk.core.ValueCommandInput.classType())
     commandUIState.initValue(BIN_SCREW_DIAMETER_INPUT, const.DIMENSION_SCREW_HOLE_DIAMETER, adsk.core.ValueCommandInput.classType())
     commandUIState.initValue(BIN_MAGNET_CUTOUTS_INPUT_ID, False, adsk.core.BoolValueCommandInput.classType())
+    commandUIState.initValue(BIN_MAGNET_CUTOUTS_TABS_INPUT_ID, False, adsk.core.BoolValueCommandInput.classType())
     commandUIState.initValue(BIN_MAGNET_DIAMETER_INPUT, const.DIMENSION_MAGNET_CUTOUT_DIAMETER, adsk.core.ValueCommandInput.classType())
     commandUIState.initValue(BIN_MAGNET_HEIGHT_INPUT, const.DIMENSION_MAGNET_CUTOUT_DEPTH, adsk.core.ValueCommandInput.classType())
 
@@ -434,6 +436,7 @@ def is_all_input_valid(inputs: adsk.core.CommandInputs):
     bin_wall_thickness: adsk.core.ValueCommandInput = inputs.itemById(BIN_WALL_THICKNESS_INPUT_ID)
     bin_screw_holes: adsk.core.BoolValueCommandInput = inputs.itemById(BIN_SCREW_HOLES_INPUT_ID)
     bin_magnet_cutouts: adsk.core.BoolValueCommandInput = inputs.itemById(BIN_MAGNET_CUTOUTS_INPUT_ID)
+    bin_magnet_cutouts_tabs: asdk.core.BoolValueCommandInput = inputs.itemById(BIN_MAGNET_CUTOUTS_TABS_INPUT_ID)
     bin_generate_base: adsk.core.BoolValueCommandInput = inputs.itemById(BIN_GENERATE_BASE_INPUT_ID)
     bin_generate_body: adsk.core.BoolValueCommandInput = inputs.itemById(BIN_GENERATE_BODY_INPUT_ID)
     bin_screw_hole_diameter: adsk.core.ValueCommandInput = inputs.itemById(BIN_SCREW_DIAMETER_INPUT)
@@ -642,6 +645,8 @@ def command_created(args: adsk.core.CommandCreatedEventArgs):
     magnetHeightInput.minimumValue = 0.1
     magnetHeightInput.isMinimumInclusive = True
     commandUIState.registerCommandInput(magnetHeightInput)
+    generateMagnetsTabCheckboxInput = baseFeaturesGroup.children.addBoolValueInput(BIN_MAGNET_CUTOUTS_TABS_INPUT_ID, 'Add tabs to magnet cutout', True, '', commandUIState.getState(BIN_MAGNET_CUTOUTS_TABS_INPUT_ID))
+    commandUIState.registerCommandInput(generateMagnetsTabCheckboxInput)
 
     userChangesGroup = inputs.addGroupCommandInput(USER_CHANGES_GROUP_ID, 'Changes')
     userChangesGroup.isExpanded = commandUIState.getState(USER_CHANGES_GROUP_ID)
@@ -794,6 +799,7 @@ def onChangeValidate():
     generateBase: bool = commandUIState.getState(BIN_GENERATE_BASE_INPUT_ID)
     commandUIState.getInput(BIN_SCREW_HOLES_INPUT_ID).isEnabled = generateBase
     commandUIState.getInput(BIN_MAGNET_CUTOUTS_INPUT_ID).isEnabled = generateBase
+    commandUIState.getInput(BIN_MAGNET_CUTOUTS_TABS_INPUT_ID).isEnabled = generateBase
     commandUIState.getInput(BIN_MAGNET_DIAMETER_INPUT).isEnabled = generateBase
     commandUIState.getInput(BIN_MAGNET_HEIGHT_INPUT).isEnabled = generateBase
     commandUIState.getInput(BIN_SCREW_DIAMETER_INPUT).isEnabled = generateBase
@@ -852,6 +858,7 @@ def generateBin(args: adsk.core.CommandEventArgs):
     bin_generate_base: adsk.core.BoolValueCommandInput = inputs.itemById(BIN_GENERATE_BASE_INPUT_ID)
     bin_generate_body: adsk.core.BoolValueCommandInput = inputs.itemById(BIN_GENERATE_BODY_INPUT_ID)
     bin_magnet_cutouts: adsk.core.BoolValueCommandInput = inputs.itemById(BIN_MAGNET_CUTOUTS_INPUT_ID)
+    bin_magnet_cutouts_tabs: adsk.core.BoolValueCommandInput = inputs.itemById(BIN_MAGNET_CUTOUTS_TABS_INPUT_ID)
     bin_screw_hole_diameter: adsk.core.ValueCommandInput = inputs.itemById(BIN_SCREW_DIAMETER_INPUT)
     bin_magnet_cutout_diameter: adsk.core.ValueCommandInput = inputs.itemById(BIN_MAGNET_DIAMETER_INPUT)
     bin_magnet_cutout_depth: adsk.core.ValueCommandInput = inputs.itemById(BIN_MAGNET_HEIGHT_INPUT)
@@ -897,6 +904,7 @@ def generateBin(args: adsk.core.CommandEventArgs):
         baseGeneratorInput.xyClearance = xyClearance
         baseGeneratorInput.hasScrewHoles = bin_screw_holes.value and not isShelled
         baseGeneratorInput.hasMagnetCutouts = bin_magnet_cutouts.value and not isShelled
+        baseGeneratorInput.hasMagnetCutoutsTabs = bin_magnet_cutouts_tabs.value and not isShelled
         baseGeneratorInput.screwHolesDiameter = bin_screw_hole_diameter.value
         baseGeneratorInput.magnetCutoutsDiameter = bin_magnet_cutout_diameter.value
         baseGeneratorInput.magnetCutoutsDepth = bin_magnet_cutout_depth.value

--- a/lib/gridfinityUtils/baseGenerator.py
+++ b/lib/gridfinityUtils/baseGenerator.py
@@ -150,6 +150,20 @@ def createGridfinityBase(
         )
         cutoutBodies.add(magnetSocketBody)
         
+        if input.hasMagnetCutoutsTabs:
+            tab_offset = input.magnetCutoutsDiameter / 4
+            tab_offset = 0
+            tabBody = shapeUtils.simpleBox(
+                baseBottomPlane,
+                0,
+                input.magnetCutoutsDiameter / 2,
+                input.magnetCutoutsDiameter / 2,
+                -input.magnetCutoutsDepth,
+                adsk.core.Point3D.create(baseHoleCenterPoint.x - tab_offset, baseHoleCenterPoint.y + tab_offset, 0),
+                targetComponent,
+            )
+            cutoutBodies.add(tabBody)
+
         if input.hasScrewHoles and (const.BIN_BASE_HEIGHT - input.magnetCutoutsDepth) > const.BIN_MAGNET_HOLE_GROOVE_DEPTH:
             grooveBody = shapeUtils.simpleCylinder(
                 baseBottomPlane,
@@ -183,6 +197,7 @@ def createGridfinityBase(
 
 
     if input.hasScrewHoles or input.hasMagnetCutouts:
+        # FIXME: Possibly insert the magnetcutouttabs here instead for directionality
         if cutoutBodies.count > 1:
             joinFeature = combineUtils.joinBodies(cutoutBodies.item(0), commonUtils.objectCollectionFromList(list(cutoutBodies)[1:]), targetComponent)
             cutoutBodies = commonUtils.objectCollectionFromList(joinFeature.bodies)

--- a/lib/gridfinityUtils/baseGeneratorInput.py
+++ b/lib/gridfinityUtils/baseGeneratorInput.py
@@ -7,6 +7,7 @@ class BaseGeneratorInput():
         self.hasMagnetCutouts = False
         self.hasScrewHoles = False
         self.hasBottomChamfer = True
+        self.hasMagnetCutoutsTabs = False
         self.screwHolesDiameter = DIMENSION_SCREW_HOLE_DIAMETER
         self.magnetCutoutsDiameter = DIMENSION_MAGNET_CUTOUT_DIAMETER
         self.magnetCutoutsDepth = DIMENSION_MAGNET_CUTOUT_DEPTH
@@ -74,6 +75,14 @@ class BaseGeneratorInput():
     @hasMagnetCutouts.setter
     def hasMagnetCutouts(self, value: bool):
         self._hasMagnetCutouts = value
+
+    @property
+    def hasMagnetCutoutsTabs(self) -> bool:
+        return self._hasMagnetCutoutsTabs
+
+    @hasMagnetCutoutsTabs.setter
+    def hasMagnetCutoutsTabs(self, value: bool):
+        self._hasMagnetCutoutsTabs = value
 
     @property
     def magnetCutoutsDiameter(self) -> float:


### PR DESCRIPTION
for people that use pressfit instead of glue.

This is a proof of concept that needs refinement by someone that uses pressfit. Areas of future consideration:

* Removing 1/4 of the surface area when you press-fit seems counter-productive. Less should be more.

* Some press-fit models make the tab even deeper than the magnet hole so you can get a tool under the magnet when prying it out.

* At least for asthetic reasons it would probably be nicer to tave all tabs poing towards the middle.